### PR TITLE
feat: Add label to Azure config for run tracking

### DIFF
--- a/.github/actions/update-azure-config/action.yml
+++ b/.github/actions/update-azure-config/action.yml
@@ -29,3 +29,4 @@ runs:
           --content-type application/json \
           --yes \
           --connection-string "${{ inputs.AZURE_APP_CONFIG_CONNECTION_STRING }}"
+          --label "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}" # this helps track which run set this value


### PR DESCRIPTION
This adds the URL of the run to the KV change history in azure app config that helps debug KV history when needed.