### PR TITLE
fix: add missing line continuation in azure config action

### DIFF
--- a/.github/actions/update-azure-config/action.yml
+++ b/.github/actions/update-azure-config/action.yml
@@ -28,5 +28,5 @@ runs:
           --value "$(jq -n --arg wid '${{ inputs.widgetId }}' --arg ver '${{ inputs.nextVersion }}' '{widgetId: $wid, version: $ver}')" \
           --content-type application/json \
           --yes \
-          --connection-string "${{ inputs.AZURE_APP_CONFIG_CONNECTION_STRING }}"
+          --connection-string "${{ inputs.AZURE_APP_CONFIG_CONNECTION_STRING }}" \
           --label "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}" # this helps track which run set this value


### PR DESCRIPTION
- Add backslash at end of --connection-string line
- Fixes 'command not found' error for --label parameter
- Shell was treating --label as separate command instead of continuation
- Now az appconfig kv set command properly includes all parameters